### PR TITLE
Increase goal, loan, and budget creation limit

### DIFF
--- a/budget/assets/translations/generated/en.json
+++ b/budget/assets/translations/generated/en.json
@@ -375,7 +375,7 @@
   "support-the-developer": "Support the developer",
   "support-the-developer-description": "More than 3 years of development",
   "unlimited-budgets-and-goals": "Unlimited budgets",
-  "unlimited-budgets-and-goals-description": "Create more than 1 budget, goal, or loan",
+  "unlimited-budgets-and-goals-description": "Create more than 5 budgets, goals, or loans",
   "past-budget-periods": "Past budget periods",
   "past-budget-periods-description": "View spending breakdowns of past periods",
   "unlimited-color-picker": "Unlimited color picker",

--- a/budget/lib/pages/premiumPage.dart
+++ b/budget/lib/pages/premiumPage.dart
@@ -737,7 +737,7 @@ Future<bool> premiumPopupPushRoute(BuildContext context) async {
 
 Future<bool> premiumPopupBudgets(BuildContext context) async {
   if (hidePremiumPopup()) return true;
-  if ((await database.getAllBudgets()).length > 0) {
+  if ((await database.getAllBudgets()).length > 4) {
     if (await premiumPopupPushRoute(context) == true) {
       return true;
     } else {
@@ -753,7 +753,7 @@ Future<bool> premiumPopupObjectives(BuildContext context,
     {required ObjectiveType objectiveType}) async {
   if (hidePremiumPopup()) return true;
   if ((await database.getAllObjectives(objectiveType: objectiveType)).length >
-      0) {
+      4) {
     if (await premiumPopupPushRoute(context) == true) {
       return true;
     } else {


### PR DESCRIPTION
Increase the free limit for budgets, goals, and loans from 1 to 5, and update the corresponding premium description.

---
<a href="https://cursor.com/background-agent?bcId=bc-90c36951-c457-454d-91b1-8bd80d918927">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-90c36951-c457-454d-91b1-8bd80d918927">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

